### PR TITLE
Init sync skip truncate

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ tables:
         buffer_row_id: {clickhouse buffer table column name for row id} 
         init_sync_skip: {skip initial copy of the data}
         init_sync_skip_buffer_table: {if true bypass buffer_table and write directly to the main_table on initial sync copy}
-                                     # makes sense in case of huge tables            
+                                     # makes sense in case of huge tables        
+        init_sync_skip_truncate: {skip truncate of the main_table during init sync}                                 
         engine: {clickhouse table engine: MergeTree, ReplacingMergeTree or CollapsingMergeTree}
         max_buffer_length: {number of DML(insert/update/delete) commands to store in the memory before flushing to the buffer/main table } 
         merge_threshold: {if buffer table specified, number of buffer flushed before moving data from buffer to the main table}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,6 +72,7 @@ type Table struct {
 	FlushThreshold          int               `yaml:"flush_threshold"`
 	InitSyncSkip            bool              `yaml:"init_sync_skip"`
 	InitSyncSkipBufferTable bool              `yaml:"init_sync_skip_buffer_table"`
+	InitSyncSkipTruncate    bool              `yaml:"init_sync_skip_truncate"`
 	EmptyValues             map[string]string `yaml:"empty_values"`
 	Columns                 map[string]string `yaml:"columns"`
 

--- a/pkg/replicator/replicator.go
+++ b/pkg/replicator/replicator.go
@@ -184,9 +184,9 @@ func (r *Replicator) getCurrentState() error {
 		err error
 	)
 
-	r.stateLSNfp, err = os.OpenFile(r.cfg.LsnStateFilepath, os.O_RDWR, os.ModePerm)
+	r.stateLSNfp, err = os.OpenFile(r.cfg.LsnStateFilepath, os.O_RDWR, os.FileMode(0666))
 	if os.IsNotExist(err) {
-		r.stateLSNfp, err = os.OpenFile(r.cfg.LsnStateFilepath, os.O_WRONLY|os.O_CREATE, os.ModePerm)
+		r.stateLSNfp, err = os.OpenFile(r.cfg.LsnStateFilepath, os.O_WRONLY|os.O_CREATE, os.FileMode(0666))
 		if err != nil {
 			return fmt.Errorf("could not create file: %v", err)
 		}

--- a/pkg/tableengines/generic.go
+++ b/pkg/tableengines/generic.go
@@ -171,8 +171,10 @@ func (t *genericTable) genSync(pgTx *pgx.Tx, w io.Writer) error {
 	} else {
 		log.Printf("Copy from %s postgres table to %q clickhouse table started",
 			t.cfg.PgTableName.String(), t.cfg.ChMainTable)
-		if err := t.truncateMainTable(); err != nil {
-			return fmt.Errorf("could not truncate main table: %v", err)
+		if !t.cfg.InitSyncSkipTruncate {
+			if err := t.truncateMainTable(); err != nil {
+				return fmt.Errorf("could not truncate main table: %v", err)
+			}
 		}
 	}
 
@@ -193,8 +195,10 @@ func (t *genericTable) genSync(pgTx *pgx.Tx, w io.Writer) error {
 	t.bufferRowId = 0
 
 	if t.cfg.ChBufferTable != "" && !t.cfg.InitSyncSkipBufferTable {
-		if err := t.truncateMainTable(); err != nil {
-			return fmt.Errorf("could not truncate main table: %v", err)
+		if !t.cfg.InitSyncSkipTruncate {
+			if err := t.truncateMainTable(); err != nil {
+				return fmt.Errorf("could not truncate main table: %v", err)
+			}
 		}
 
 		t.bufferFlushCnt++


### PR DESCRIPTION
new config parameter `init_sync_skip_truncate` can be used in case you need to replicate multiple pg tables into a single clickhouse table