### PR TITLE
Fix UUID conversion

### DIFF
--- a/pkg/tableengines/generic.go
+++ b/pkg/tableengines/generic.go
@@ -470,6 +470,8 @@ func convert(val string, chType config.ChColumn, pgType config.PgColumn) (interf
 		return time.Parse("2006-01-02", val[:10])
 	case utils.ChDateTime:
 		return time.Parse("2006-01-02 15:04:05", val[:19])
+	case utils.ChUUID:
+		return val, nil
 	}
 
 	return nil, fmt.Errorf("unknown type: %v", chType)


### PR DESCRIPTION
This change was necessary to import a PG table with a UUID type, mapped to a CH table UUID column.

Prior to making it:
`[..] could not parse record: could not parse "id" field with UUID type: unknown type: {{UUID false false []} id}`

Not sure if this is the right way to fix, but it worked so I thought I'd file a patch instead of an issue. ;)

Thanks!